### PR TITLE
#5: Ignore properties with the CompilerGenerated attribute, as for fields.

### DIFF
--- a/src/Extensions.Configuration.Object/Internal/ReflectionExtensions.cs
+++ b/src/Extensions.Configuration.Object/Internal/ReflectionExtensions.cs
@@ -45,6 +45,13 @@ namespace Extensions.Configuration.Object.Internal
         {
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
             var properties = type.GetProperties(bindingFlags);
+            
+            if (!type.IsAnonymous())
+            {
+                return properties
+                    .Where(x => !x.IsCompilerGenerated())
+                    .ToArray();
+            }
 
             return properties;
         }

--- a/test/Extensionsions.Configuration.Object.UnitTests/RecordObjectTest.cs
+++ b/test/Extensionsions.Configuration.Object.UnitTests/RecordObjectTest.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Extensions.Configuration.Object.UnitTests
+{
+    public class RecordObjectTest
+    {
+        internal record MyConfiguration
+        {
+            public SubRecordConfiguration SubRecord;
+            public string MyKey;
+        }
+
+        internal record SubRecordConfiguration
+        {
+            public string Title;
+            public string Name;
+            public int Age;
+        }
+
+        [Fact]
+        public void AddObject_WithClassObject_ShouldLoadFieldsIntoConfiguration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddObject(new MyConfiguration
+                {
+                    SubRecord = new SubRecordConfiguration
+                    {
+                        Title = "Editor",
+                        Name = "Joe Smith",
+                        Age = 33
+                    },
+                    MyKey = "My appsettings.json Value",
+                })
+                .Build();
+
+            configuration["SubRecord:Title"].Should().Be("Editor");
+            configuration["SubRecord:Name"].Should().Be("Joe Smith");
+            configuration["SubRecord:Age"].Should().Be("33");
+            configuration["MyKey"].Should().Be("My appsettings.json Value");
+        }
+    }
+}

--- a/test/Extensionsions.Configuration.Object.UnitTests/RecordObjectTest.cs
+++ b/test/Extensionsions.Configuration.Object.UnitTests/RecordObjectTest.cs
@@ -20,7 +20,7 @@ namespace Extensions.Configuration.Object.UnitTests
         }
 
         [Fact]
-        public void AddObject_WithClassObject_ShouldLoadFieldsIntoConfiguration()
+        public void AddObject_WithRecordObject_ShouldLoadFieldsIntoConfiguration()
         {
             var configuration = new ConfigurationBuilder()
                 .AddObject(new MyConfiguration


### PR DESCRIPTION
C# Records have a `EqualityContract `property of type `Type`, which causes a StackOverflowException in `LoadRecursively()`. This PR copies the check for the `CompilerGenerated` attribute to run also for properties, as it does for fields.